### PR TITLE
Release 1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,3 +5,4 @@
 ## [Unreleased]
 
 - Switched from play-sound to find-exec for playing audio files as play-sound didn't offer much in terms of functionality, and most of what it offered had to be overwritten anyways.
+- Added ability to configure which audio players to use.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,3 +8,4 @@
 - Added ability to configure which audio players to use.
 - Added ability to configure what arguments are used with which audio players.
 - Configuration changes are now loaded live and only one remains that still requires reloading.
+- Added ability to configure at which error severity level to play the Vine boom.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,4 +4,4 @@
 
 ## [Unreleased]
 
-- Nothing...
+- Switched from play-sound to find-exec for playing audio files as play-sound didn't offer much in terms of functionality, and most of what it offered had to be overwritten anyways.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,3 +7,4 @@
 - Switched from play-sound to find-exec for playing audio files as play-sound didn't offer much in terms of functionality, and most of what it offered had to be overwritten anyways.
 - Added ability to configure which audio players to use.
 - Added ability to configure what arguments are used with which audio players.
+- Configuration changes are now loaded live and only one remains that still requires reloading.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,3 +6,4 @@
 
 - Switched from play-sound to find-exec for playing audio files as play-sound didn't offer much in terms of functionality, and most of what it offered had to be overwritten anyways.
 - Added ability to configure which audio players to use.
+- Added ability to configure what arguments are used with which audio players.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,11 @@
 # Change Log
 
-- Initial release
-
-## [Unreleased]
-
 - Switched from play-sound to find-exec for playing audio files as play-sound didn't offer much in terms of functionality, and most of what it offered had to be overwritten anyways.
 - Added ability to configure which audio players to use.
 - Added ability to configure what arguments are used with which audio players.
 - Configuration changes are now loaded live and only one remains that still requires reloading.
 - Added ability to configure at which error severity level to play the Vine boom.
+
+## [Unreleased]
+
+- Nothing...

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Plays the Vine boom sound effect when your badly-written code generates errors.
 ## Configuration
 
 - `vineBoomErrors.playBoomOnError`
-    - If true, plays the Vine boom sound effect when an error is produced by a linter or static analysis.
+    - If `true`, plays the Vine boom sound effect when an error is produced by a linter or static analysis.
     - Default: `true`  
 - `vineBoomErrors.soundEffectLocation`
     - If left blank, uses the Vine boom sound stored in the extension directory. You can put a path to another sound file to change the sound played.
@@ -21,6 +21,9 @@ Plays the Vine boom sound effect when your badly-written code generates errors.
     - The time, in milliseconds, to space apart each Vine boom.
     - Allowable values: `non-negative`
     - Default: `100`
+- `vineBoomErrors.players`
+    - The command-line players to play the Vine boom effect with. Uses the first one found to be present, searching from left to right. If one of the present players causes issues, remove it. If your player is not present, add it to the front. Must be compatible with MP3s.
+    - Default: `["mplayer", "mpv", "ffplay", "omxplayer", "cmdmp3win", "cvlc", "play", "mpg123"]`
 
 ## How to build
 

--- a/README.md
+++ b/README.md
@@ -23,11 +23,15 @@ Plays the Vine boom sound effect when your badly-written code generates errors.
     - Default: `100`
 - `vineBoomErrors.players`
     - The command-line players to play the Vine boom effect with. Uses the first one found to be present, searching from left to right. If one of the present players causes issues, remove it. If your player is not present, add it to the front. Must be compatible with MP3s.
-    - Default: `["mplayer", "mpv", "ffplay", "omxplayer", "cmdmp3win", "cvlc", "play", "mpg123"]`
+    - Default: `"mplayer"`, `"mpv"`, `"ffplay"`, `"omxplayer"`, `"cmdmp3win"`, `"cvlc"`, `"play"`, `"mpg123"`
     - Reload for changes to take effect.
 - `vineBoomErrors.playerOptions`
     - Command-line options to supply to the players. Keys are the names of the players and must be the same as in `vineBoomErrors.players`. At a minimum, any options that close the player after playing and prevent it from opening any windows are required if that is not the default behavior.
-    - Default: `{"ffplay": ["-nodisp", "-autoexit"], "cvlc": ["--play-and-exit"]}`
+    - Default: `"ffplay": ["-nodisp", "-autoexit"]`, `"cvlc": ["--play-and-exit"]`
+- `vineBoomErrors.minimumSeverity`
+    - The minimum diagnostic severity level at which to play the Vine boom. Choosing an option also chooses all of the options before it.
+    - Allowable values: `"Error"`, `"Warning"`, `"Information"`, `"Hint"`
+    - Default: `"Error"`
 
 ## How to build
 

--- a/README.md
+++ b/README.md
@@ -43,14 +43,6 @@ code --install-extension <package name goes here>
 ```
 
 Make sure to reload or restart Visual Studio Code after installing .
-  
-## Release Notes
-
-Initial release.
-
-### 0.1.0
-
-Initial release.
 
 ## Copyright
 

--- a/README.md
+++ b/README.md
@@ -24,6 +24,9 @@ Plays the Vine boom sound effect when your badly-written code generates errors.
 - `vineBoomErrors.players`
     - The command-line players to play the Vine boom effect with. Uses the first one found to be present, searching from left to right. If one of the present players causes issues, remove it. If your player is not present, add it to the front. Must be compatible with MP3s.
     - Default: `["mplayer", "mpv", "ffplay", "omxplayer", "cmdmp3win", "cvlc", "play", "mpg123"]`
+- `vineBoomErrors.playerOptions`
+    - Command-line options to supply to the players. Keys are the names of the players and must be the same as in `vineBoomErrors.players`. At a minimum, any options that close the player after playing and prevent it from opening any windows are required if that is not the default behavior.
+    - Default: `{"ffplay": ["-nodisp", "-autoexit"], "cvlc": ["--play-and-exit"]}`
 
 ## How to build
 

--- a/README.md
+++ b/README.md
@@ -55,6 +55,18 @@ code --install-extension <package name goes here>
 
 Make sure to reload or restart Visual Studio Code after installing .
 
+## Release Notes
+
+- Switched from play-sound to find-exec for playing audio files as play-sound didn't offer much in terms of functionality, and most of what it offered had to be overwritten anyways.
+- Added ability to configure which audio players to use.
+- Added ability to configure what arguments are used with which audio players.
+- Configuration changes are now loaded live and only one remains that still requires reloading.
+- Added ability to configure at which error severity level to play the Vine boom.
+
+### 0.1.0
+
+- Initial release.
+
 ## Copyright
 
 The logo is derived from Vine's logo © 2018 Twitter, Inc.

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Plays the Vine boom sound effect when your badly-written code generates errors.
 - `vineBoomErrors.players`
     - The command-line players to play the Vine boom effect with. Uses the first one found to be present, searching from left to right. If one of the present players causes issues, remove it. If your player is not present, add it to the front. Must be compatible with MP3s.
     - Default: `["mplayer", "mpv", "ffplay", "omxplayer", "cmdmp3win", "cvlc", "play", "mpg123"]`
+    - Reload for changes to take effect.
 - `vineBoomErrors.playerOptions`
     - Command-line options to supply to the players. Keys are the names of the players and must be the same as in `vineBoomErrors.players`. At a minimum, any options that close the player after playing and prevent it from opening any windows are required if that is not the default behavior.
     - Default: `{"ffplay": ["-nodisp", "-autoexit"], "cvlc": ["--play-and-exit"]}`

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,14 +1,15 @@
 {
   "name": "vineboomerrors",
-  "version": "0.0.1",
+  "version": "0.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "vineboomerrors",
-      "version": "0.0.1",
+      "version": "0.1.0",
+      "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
-        "play-sound": "^1.1.5"
+        "find-exec": "^1.0.2"
       },
       "devDependencies": {
         "@types/glob": "^8.0.0",
@@ -2639,14 +2640,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/play-sound": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/play-sound/-/play-sound-1.1.5.tgz",
-      "integrity": "sha512-gbdF1iLNyL5r9Ne9YwARGMkrvfR4EL9G1ZLtFPLkI2tQt0kkHw5CHM5E6Gl/lDuuk/Uj/O5Q29Bi08jMK4egbA==",
-      "dependencies": {
-        "find-exec": "1.0.2"
       }
     },
     "node_modules/prelude-ls": {
@@ -5545,14 +5538,6 @@
             "p-limit": "^2.2.0"
           }
         }
-      }
-    },
-    "play-sound": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/play-sound/-/play-sound-1.1.5.tgz",
-      "integrity": "sha512-gbdF1iLNyL5r9Ne9YwARGMkrvfR4EL9G1ZLtFPLkI2tQt0kkHw5CHM5E6Gl/lDuuk/Uj/O5Q29Bi08jMK4egbA==",
-      "requires": {
-        "find-exec": "1.0.2"
       }
     },
     "prelude-ls": {

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
           "items": {
             "type": "string"
           },
-          "description": "The command-line players to play the Vine boom effect with. Uses the first one found to be present, searching from first to last. If one of the present players causes issues, remove it. If your player is not present, add it to the front. Must be compatible with MP3s."
+          "description": "The command-line players to play the Vine boom effect with. Uses the first one found to be present, searching from first to last. If one of the present players causes issues, remove it. If your player is not present, add it to the front. Must be compatible with MP3s. Reload for changes to take effect."
         },
         "vineBoomErrors.playerOptions": {
           "type": "object",

--- a/package.json
+++ b/package.json
@@ -69,7 +69,24 @@
           "default": [ "mplayer", "mpv", "ffplay", "omxplayer", "cmdmp3win", "cvlc", "play", "mpg123"
                      , "mpg321"],
           "minItems": 1,
-          "description": "The command-line players to play the Vine boom effect with. Uses the first one found to be present, searching from left to right. If one of the present players causes issues, remove it. If your player is not present, add it to the front. Must be compatible with MP3s."
+          "items": {
+            "type": "string"
+          },
+          "description": "The command-line players to play the Vine boom effect with. Uses the first one found to be present, searching from first to last. If one of the present players causes issues, remove it. If your player is not present, add it to the front. Must be compatible with MP3s."
+        },
+        "vineBoomErrors.playerOptions": {
+          "type": "object",
+          "default": {
+            "ffplay": ["-nodisp", "-autoexit"],
+            "cvlc": ["--play-and-exit"]
+          },
+          "additionalProperties": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "description": "Command-line options to supply to the players. Keys are the names of the players and must be the same as in vineBoomErrors.players. At a minimum, any options that close the player after playing and prevent it from opening any windows are required if that is not the default behavior."
         }
       }
     }

--- a/package.json
+++ b/package.json
@@ -63,6 +63,13 @@
           "default": 100,
           "minimum": 0,
           "description": "The time, in milliseconds, to space apart each Vine boom."
+        },
+        "vineBoomErrors.players": {
+          "type": "array",
+          "default": [ "mplayer", "mpv", "ffplay", "omxplayer", "cmdmp3win", "cvlc", "play", "mpg123"
+                     , "mpg321"],
+          "minItems": 1,
+          "description": "The command-line players to play the Vine boom effect with. Uses the first one found to be present, searching from left to right. If one of the present players causes issues, remove it. If your player is not present, add it to the front. Must be compatible with MP3s."
         }
       }
     }

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
         "category": "VineBoomErrors"
       }
     ],
-    "configuration":{
+    "configuration": {
       "title": "VineBoomErrors",
       "properties": {
         "vineBoomErrors.playBoomOnError": {
@@ -95,6 +95,6 @@
     "webpack-cli": "^4.10.0"
   },
   "dependencies": {
-    "play-sound": "^1.1.5"
+    "find-exec": "^1.0.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "vineboomerrors",
   "displayName": "VineBoomErrors",
   "description": "Plays the Vine boom sound effect when your badly-written code generates errors",
-  "version": "0.1.0",
+  "version": "1.0.0",
   "publisher": "onalitokiejanEpiphanytawami",
   "author": {
     "name": "ona li toki e jan Epiphany tawa mi"

--- a/package.json
+++ b/package.json
@@ -87,6 +87,18 @@
             }
           },
           "description": "Command-line options to supply to the players. Keys are the names of the players and must be the same as in vineBoomErrors.players. At a minimum, any options that close the player after playing and prevent it from opening any windows are required if that is not the default behavior."
+        },
+        "vineBoomErrors.minimumSeverity": {
+          "type": "string",
+          "enum": ["Error", "Warning", "Information", "Hint"],
+          "enumDescriptions": [
+            "Something not allowed by the rules of a language or other means.",
+            "Something suspicious but allowed.",
+            "Something to inform about but not a problem.",
+            "Something to hint to a better way of doing it, like proposing a refactoring."
+          ],
+          "default": "Error",
+          "description": "The minimum diagnostic severity level at which to play the Vine boom. Choosing an option also chooses all of the options before it."
         }
       }
     }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,5 +1,3 @@
-// TODO Possible add config option to select error severity.
-
 import * as vscode from "vscode";
 const commands  		 = vscode.commands;
 const window      		 = vscode.window;
@@ -20,6 +18,20 @@ const R_OK = fs.constants.R_OK;
 };
 
 
+
+/**
+ * Configuration option paths packed into a neat little enum.
+ */
+enum Configuration {
+	SECTION = "vineBoomErrors",
+
+	PLAY_BOOM_ON_ERROR    = "playBoomOnError",
+	SOUND_EFFECT_LOCATION = "soundEffectLocation",
+	DELAY 				  = "delay",
+	PLAYERS 			  = "players",
+	PLAYER_OPTIONS 		  = "playerOptions",
+	MINIMUM_SEVERITY 	  = "minimumSeverity"
+}
 
 // Whether to play the Vine boom if an error occurs.
 let playBoomOnError = true;
@@ -48,45 +60,45 @@ let minimumSeverity: string = "Error";
 function loadConfiguration(context: vscode.ExtensionContext, 
 						   event: vscode.ConfigurationChangeEvent | null = null) {
 	function throwNoFetch(configurationName: string, recievedValue: any) {
-		throw `ERROR: Unable to fetch configuration "vineBoomErrors.${configurationName}"! Recieved: ${playBoomOnError}`;
+		throw `ERROR: Unable to fetch configuration "${Configuration.SECTION}.${configurationName}"! Recieved: ${playBoomOnError}`;
 	}
 
 	// If a ConfigurationChangeEvent occurs and it isn't for us we don't need to do anything.
-	if (event && !event.affectsConfiguration("vineBoomErrors"))
+	if (event && !event.affectsConfiguration(Configuration.SECTION))
 		return;
 	
-	const configuration = workspace.getConfiguration("vineBoomErrors");
+	const configuration = workspace.getConfiguration(Configuration.SECTION);
 
 	// @ts-ignore
-	playBoomOnError = configuration.get("playBoomOnError");
+	playBoomOnError = configuration.get(Configuration.PLAY_BOOM_ON_ERROR);
 	if (typeof playBoomOnError !== "boolean")
-		throwNoFetch("playBoomOnError", playBoomOnError);
+		throwNoFetch(Configuration.PLAY_BOOM_ON_ERROR, playBoomOnError);
 
 	// @ts-ignore
-	vineBoomFile = configuration.get("soundEffectLocation")
+	vineBoomFile = configuration.get(Configuration.SOUND_EFFECT_LOCATION);
 	if (typeof vineBoomFile !== "string")
-		throwNoFetch("soundEffectLocation", vineBoomFile);
+		throwNoFetch(Configuration.SOUND_EFFECT_LOCATION, vineBoomFile);
 	vineBoomFile ||= `${context.extensionPath}/audio/vineboom.mp3`;
 	
 	// @ts-ignore
-	delay = configuration.get("delay");
+	delay = configuration.get(Configuration.DELAY);
 	if (typeof delay !== "number")
-		throwNoFetch("delay", delay);
+		throwNoFetch(Configuration.DELAY, delay);
 
 	// @ts-ignore
-	players = configuration.get("players");
+	players = configuration.get(Configuration.PLAYERS);
 	if (!Array.isArray(players))
-		throwNoFetch("players", players);
+		throwNoFetch(Configuration.PLAYERS, players);
 
 	// @ts-ignore
-	playerOptions = configuration.get("playerOptions");
+	playerOptions = configuration.get(Configuration.PLAYER_OPTIONS);
 	if (typeof playerOptions !== "object")
-		throwNoFetch("playerOptions", playerOptions);
+		throwNoFetch(Configuration.PLAYER_OPTIONS, playerOptions);
 
 	// @ts-ignore
-	minimumSeverity = configuration.get("minimumSeverity");
+	minimumSeverity = configuration.get(Configuration.MINIMUM_SEVERITY);
 	if (!(minimumSeverity in DiagnosticSeverity))
-		throwNoFetch("minimumSeverity", minimumSeverity);
+		throwNoFetch(Configuration.MINIMUM_SEVERITY, minimumSeverity);
 }
 
 
@@ -183,6 +195,11 @@ function vineboomForErrors(event: vscode.DiagnosticChangeEvent) {
 
 
 
+/**
+ * VineBoomErrors, Plays the Vine boom sound effect when your badly-written code generates errors.
+ * 
+ * @author ona li toki e jan Epiphany tawa mi.
+ */
 export function activate(context: vscode.ExtensionContext) {
 	loadConfiguration(context);
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -33,8 +33,8 @@ let players = [ "mplayer", "mpv", "ffplay", "omxplayer", "cmdmp3win"
 			  , "mpg123", "mpg321" /* Same player, different name */]
 
 // Various options to make sure players don't open any windows and exit when done.
-const playerOptions: Dictonary<string[]> = { ffplay: ["-nodisp", "-autoexit"]
-	                  					   , cvlc:   ["--play-and-exit"]};
+let playerOptions: Dictonary<string[]> = { ffplay: ["-nodisp", "-autoexit"]
+	                  					 , cvlc:   ["--play-and-exit"]};
 
 // Delay between consecutive file plays when using loopPlayFile().
 let delay = 100;
@@ -123,12 +123,13 @@ function vineboomForErrors(event: vscode.DiagnosticChangeEvent) {
 
 
 export function activate(context: vscode.ExtensionContext) {
-	const configuration = vscode.workspace.getConfiguration("vineBoomErrors");
+	const configuration   = vscode.workspace.getConfiguration("vineBoomErrors");
 	const playBoomOnError = configuration.get("playBoomOnError");
 	_vineBoomFile = configuration.get("soundEffectLocation") || 
 					`${context.extensionPath}/audio/vineboom.mp3`;
-	delay = configuration.get("delay") || delay;
-	players = configuration.get("players") || players;
+	delay         = configuration.get("delay") || delay;
+	players       = configuration.get("players") || players;
+	playerOptions = configuration.get("playerOptions") || playerOptions;
 
 
 	const playBoom = commands.registerCommand("vineBoomErrors.playBoom", () =>

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,4 +1,3 @@
-// TODO Possibly add configuration options for which players to use.
 // TODO Possible add config option to select error severity.
 
 import * as vscode from "vscode";
@@ -8,7 +7,7 @@ const languages			 = vscode.languages;
 const DiagnosticSeverity = vscode.DiagnosticSeverity;
 
 const findExec = require("find-exec");
-const spawn    = require("child_process").spawn;
+import { spawn } from "child_process";
 
 /**
  * A mapping between string keys and a given type. Just objects with a specified value type.
@@ -29,9 +28,9 @@ function getVineBoomFile(): string {
 
 // Must be mp3 compatible.
 // TODOO: omxplayer and cmdmp3win have not been tested.
-const players = [ "mplayer", "mpv", "ffplay", "omxplayer", "cmdmp3win"
-                , "cvlc" /* from VLC */, "play" /* from SoX(?) */
-			    , "mpg123", "mpg321" /* Same player, different name */]
+let players = [ "mplayer", "mpv", "ffplay", "omxplayer", "cmdmp3win"
+              , "cvlc" /* from VLC */, "play" /* from SoX(?) */
+			  , "mpg123", "mpg321" /* Same player, different name */]
 
 // Various options to make sure players don't open any windows and exit when done.
 const playerOptions: Dictonary<string[]> = { ffplay: ["-nodisp", "-autoexit"]
@@ -125,10 +124,11 @@ function vineboomForErrors(event: vscode.DiagnosticChangeEvent) {
 
 export function activate(context: vscode.ExtensionContext) {
 	const configuration = vscode.workspace.getConfiguration("vineBoomErrors");
+	const playBoomOnError = configuration.get("playBoomOnError");
 	_vineBoomFile = configuration.get("soundEffectLocation") || 
 					`${context.extensionPath}/audio/vineboom.mp3`;
 	delay = configuration.get("delay") || delay;
-	const playBoomOnError = configuration.get("playBoomOnError");
+	players = configuration.get("players") || players;
 
 
 	const playBoom = commands.registerCommand("vineBoomErrors.playBoom", () =>


### PR DESCRIPTION
# Change Log

- Switched from play-sound to find-exec for playing audio files as play-sound didn't offer much in terms of functionality, and most of what it offered had to be overwritten anyways.
- Added ability to configure which audio players to use.
- Added ability to configure what arguments are used with which audio players.
- Configuration changes are now loaded live and only one remains that still requires reloading.
- Added ability to configure at which error severity level to play the Vine boom.